### PR TITLE
setup logging example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ venv
 
 .DS_Store
 .idea
+*.log

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "frontend"]
 	path = frontend
 	url = https://github.com/litsynp/react-todo-example.git
+[submodule "logging-example"]
+	path = logging-example
+	url = https://github.com/0BVer/logging-example.git

--- a/README.ko.md
+++ b/README.ko.md
@@ -73,6 +73,8 @@ Docker를 이용한 간단한 full stack 개발을 위해 만들어진 예시용
 
 ## ELK 로깅
 
+![es-index-management-screenshot](https://user-images.githubusercontent.com/42485462/213172320-be589d5e-81c0-4c2f-bdcd-5031d45cd834.png)
+
 - logging-example 서브 모듈을 사용하여 **배포 버전**에서 로깅이 가능합니다.
 - *단일 compose 파일 실행시 동작하지 않습니다.*
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -70,3 +70,31 @@ Docker를 이용한 간단한 full stack 개발을 위해 만들어진 예시용
 `.gitignore` 파일에 `.env`를 추가해 Git repository에 추가되지 않도록 합시다.
 
 - `settings` 디렉토리에 예시를 위한 `dev`, `prod` 빌드 버전의 `.env` 파일이 존재합니다.
+
+## ELK 로깅
+
+- logging-example 서브 모듈을 사용하여 **배포 버전**에서 로깅이 가능합니다.
+- *단일 compose 파일 실행시 동작하지 않습니다.*
+
+### 동작 방식
+1. NGINX의 로그파일을 Filebeat로 수집
+2. 수집한 로그를 Logstash에 전달
+3. 전달 받은 로그를 Elasticsearch에 저장
+4. 저장된 로그를 Kibana를 통해 분석
+
+### 사용법
+
+  ```sh
+ $ docker compose -f docker-compose.prod.yml -f docker-compose.logging.yml up --build
+  ```
+
+### Kibana를 통한 로그 시각화 방법
+1. localhost:5601 접속
+2. 상단 메뉴에서 index management 검색 
+3. 수집된 로그 인덱스 확인 weblogs-yyyy.MM.dd 형식
+4. 좌측 메뉴의 Analytics의 Dashboard 클릭
+5. Create data view를 통해 인덱스 선택
+   - 전체 조회 : Index Pattern에 `weblogs-*` 입력 및 저장
+   - 선택 조회 : Index Pattern에 보고싶은 날짜입력 (eg. `weblogs-2023.01.01`)
+6. Create Visualization 클릭
+7. 보고 싶은 필드를 화면에 드롭다운 하여 시각화

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -176,12 +176,21 @@ if ENABLE_LOGGING:
                 'level': 'DEBUG',
                 'filters': ['require_debug_true'],
                 'class': 'logging.StreamHandler',
-            }
+            },
+            'logstash': {
+                'level': 'INFO',
+                'class': 'logstash.TCPLogstashHandler',
+                'host': 'logstash',   # IP/name of our Logstash EC2 instance
+                'port': 5000,
+                'version': 1,
+                'message_type': 'django',
+                'tags': ['django'],
+            },
         },
         'loggers': {
             'django.db.backends': {
                 'level': 'DEBUG',
-                'handlers': ['console'],
+                'handlers': ['console', 'logstash'],
             }
-        }
+        },
     }

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -181,15 +181,19 @@ if ENABLE_LOGGING:
                 'level': 'INFO',
                 'class': 'logstash.TCPLogstashHandler',
                 'host': 'logstash',   # IP/name of our Logstash EC2 instance
-                'port': 5000,
+                'port': 5959,
                 'version': 1,
                 'message_type': 'django',
                 'tags': ['django'],
             },
         },
         'loggers': {
+            'django': {
+                'level': 'INFO',
+                'handlers': ['console', 'logstash'],
+            },
             'django.db.backends': {
-                'level': 'DEBUG',
+                'level': 'INFO',
                 'handlers': ['console', 'logstash'],
             }
         },

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -177,24 +177,11 @@ if ENABLE_LOGGING:
                 'filters': ['require_debug_true'],
                 'class': 'logging.StreamHandler',
             },
-            'logstash': {
-                'level': 'INFO',
-                'class': 'logstash.TCPLogstashHandler',
-                'host': 'logstash',   # IP/name of our Logstash EC2 instance
-                'port': 5959,
-                'version': 1,
-                'message_type': 'django',
-                'tags': ['django'],
-            },
         },
         'loggers': {
-            'django': {
-                'level': 'INFO',
-                'handlers': ['console', 'logstash'],
-            },
             'django.db.backends': {
                 'level': 'INFO',
-                'handlers': ['console', 'logstash'],
+                'handlers': ['console'],
             }
         },
     }

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -176,12 +176,12 @@ if ENABLE_LOGGING:
                 'level': 'DEBUG',
                 'filters': ['require_debug_true'],
                 'class': 'logging.StreamHandler',
-            },
+            }
         },
         'loggers': {
             'django.db.backends': {
-                'level': 'INFO',
+                'level': 'DEBUG',
                 'handlers': ['console'],
             }
-        },
+        }
     }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ pycodestyle==2.7.0
 pytz==2021.1
 sqlparse==0.4.1
 toml==0.10.2
+python-logstash==0.4.8

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,4 +9,3 @@ pycodestyle==2.7.0
 pytz==2021.1
 sqlparse==0.4.1
 toml==0.10.2
-python-logstash==0.4.8

--- a/docker-compose.logging.yml
+++ b/docker-compose.logging.yml
@@ -1,9 +1,14 @@
+# docker-compose.prod 와 함께 실행 해야 합니다. # need to run with docker-compose.prod
+# docker compose -f docker-compose.prod.yml -f docker-compose.logging.yml up --build
+
+# changeme 로 설정된 임시 패스워드를 변경하여 사용하시길 바랍니다. # need to change temp password 'changeme'
+
 version: '3.7'
 
 services:
   elasticsearch:
     build:
-      context: ./logging-example/elasticsearch/
+      context: ./logging-example/elasticsearch
       args:
         ELASTIC_VERSION: 8.5.2
     volumes:
@@ -26,7 +31,7 @@ services:
 
   logstash:
     build:
-      context: ./logging-example/logstash/
+      context: ./logging-example/logstash
       args:
         ELASTIC_VERSION: 8.5.2
     volumes:
@@ -46,7 +51,7 @@ services:
 
   kibana:
     build:
-      context: ./logging-example/kibana/
+      context: ./logging-example/kibana
       args:
         ELASTIC_VERSION: 8.5.2
     volumes:
@@ -61,13 +66,13 @@ services:
 
   filebeat:
     build:
-      context: ./logging-example/extensions/filebeat
+      context: ./logging-example/filebeat
       args:
         ELASTIC_VERSION: 8.5.2
     entrypoint: "filebeat -e -strict.perms=false"
     volumes:
-      - ./logging-example/extensions/filebeat/config/filebeat.yml:/usr/share/filebeat/filebeat.yml
-      - ./nginx/log:/var/log/nginx
+      - ./logging-example/filebeat/config/filebeat.yml:/usr/share/filebeat/filebeat.yml
+      - ./nginx/log:/var/log/nginx # nginx log path (require same option on nginx container)
     depends_on:
       - logstash
       - elasticsearch

--- a/docker-compose.logging.yml
+++ b/docker-compose.logging.yml
@@ -33,7 +33,6 @@ services:
       - ./logging-example/logstash/config/logstash.yml:/usr/share/logstash/config/logstash.yml:ro,Z
       - ./logging-example/logstash/pipeline:/usr/share/logstash/pipeline:ro,Z
     ports:
-      - 5959:5959
       - 5044:5044
       - 50000:50000/tcp
       - 50000:50000/udp
@@ -59,6 +58,20 @@ services:
     depends_on:
       - elasticsearch
     restart: unless-stopped
+
+  filebeat:
+    build:
+      context: ./logging-example/extensions/filebeat
+      args:
+        ELASTIC_VERSION: 8.5.2
+    entrypoint: "filebeat -e -strict.perms=false"
+    volumes:
+      - ./logging-example/extensions/filebeat/config/filebeat.yml:/usr/share/filebeat/filebeat.yml
+      - ./nginx/log:/var/log/nginx
+    depends_on:
+      - logstash
+      - elasticsearch
+      - kibana
 
 volumes:
   elasticsearch:

--- a/docker-compose.logging.yml
+++ b/docker-compose.logging.yml
@@ -33,6 +33,7 @@ services:
       - ./logging-example/logstash/config/logstash.yml:/usr/share/logstash/config/logstash.yml:ro,Z
       - ./logging-example/logstash/pipeline:/usr/share/logstash/pipeline:ro,Z
     ports:
+      - 5959:5959
       - 5044:5044
       - 50000:50000/tcp
       - 50000:50000/udp

--- a/docker-compose.logging.yml
+++ b/docker-compose.logging.yml
@@ -1,0 +1,63 @@
+version: '3.7'
+
+services:
+  elasticsearch:
+    build:
+      context: ./logging-example/elasticsearch/
+      args:
+        ELASTIC_VERSION: 8.5.2
+    volumes:
+      - ./logging-example/elasticsearch/config/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro,Z
+      - elasticsearch:/usr/share/elasticsearch/data:Z
+    ports:
+      - 9200:9200
+      - 9300:9300
+    environment:
+      node.name: elasticsearch
+      ES_JAVA_OPTS: -Xms512m -Xmx512m
+      # Bootstrap password.
+      # Used to initialize the keystore during the initial startup of
+      # Elasticsearch. Ignored on subsequent runs.
+      ELASTIC_PASSWORD: changeme
+      # Use single node discovery in order to disable production mode and avoid bootstrap checks.
+      # see: https://www.elastic.co/guide/en/elasticsearch/reference/current/bootstrap-checks.html
+      discovery.type: single-node
+    restart: unless-stopped
+
+  logstash:
+    build:
+      context: ./logging-example/logstash/
+      args:
+        ELASTIC_VERSION: 8.5.2
+    volumes:
+      - ./logging-example/logstash/config/logstash.yml:/usr/share/logstash/config/logstash.yml:ro,Z
+      - ./logging-example/logstash/pipeline:/usr/share/logstash/pipeline:ro,Z
+    ports:
+      - 5044:5044
+      - 50000:50000/tcp
+      - 50000:50000/udp
+      - 9600:9600
+    environment:
+      LS_JAVA_OPTS: -Xms256m -Xmx256m
+      LOGSTASH_INTERNAL_PASSWORD: changeme
+    depends_on:
+      - elasticsearch
+    restart: unless-stopped
+
+  kibana:
+    build:
+      context: ./logging-example/kibana/
+      args:
+        ELASTIC_VERSION: 8.5.2
+    volumes:
+      - ./logging-example/kibana/config/kibana.yml:/usr/share/kibana/config/kibana.yml:ro,Z
+    ports:
+      - 5601:5601
+    environment:
+      KIBANA_SYSTEM_PASSWORD: changeme
+    depends_on:
+      - elasticsearch
+    restart: unless-stopped
+
+volumes:
+  elasticsearch:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -56,6 +56,8 @@ services:
       - static_volume:/backend/staticfiles
       - media_volume:/backend/mediafiles
       - build_folder:/var/www/frontend
+      - ./nginx/log:/var/log/nginx
+
     depends_on:
       - backend
       - frontend


### PR DESCRIPTION
### 변경점
- 원본 레포지토리에 docker-compose.logger.yml 파일 추가
- docker-compose.prod.yml 파일의 NGINX 컨테이너에 filebeat로 로그를 수집하기 위해 로그파일 볼륨 설정 추가
- Readme.ko.md 에 아래 내용 추가

## ELK 로깅

- logging-example 서브 모듈을 사용하여 **배포 버전**에서 로깅이 가능합니다.
- *단일 compose 파일 실행시 동작하지 않습니다.*

### 동작 방식
1. NGINX의 로그파일을 Filebeat로 수집
2. 수집한 로그를 Logstash에 전달
3. 전달 받은 로그를 Elasticsearch에 저장
4. 저장된 로그를 Kibana를 통해 분석

### 사용법

  ```sh
 $ docker compose -f docker-compose.prod.yml -f docker-compose.logging.yml up --build
  ```

### Kibana를 통한 로그 시각화 방법
1. localhost:5601 접속
2. 상단 메뉴에서 index management 검색 
3. 수집된 로그 인덱스 확인 weblogs-yyyy.MM.dd 형식
4. 좌측 메뉴의 Analytics의 Dashboard 클릭
5. Create data view를 통해 인덱스 선택
   - 전체 조회 : Index Pattern에 `weblogs-*` 입력 및 저장
   - 선택 조회 : Index Pattern에 보고싶은 날짜입력 (eg. `weblogs-2023.01.01`)
6. Create Visualization 클릭
7. 보고 싶은 필드를 화면에 드롭다운 하여 시각화